### PR TITLE
Remove un-used code in ActiveRecord::TypedStore

### DIFF
--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -113,14 +113,8 @@ module ActiveRecord::TypedStore
       when false, nil  then false
       else
         column = store_column_definition(store_attribute, key)
-        if column.nil?
-          if Numeric === value || value !~ /[^0-9]/
-            !value.to_i.zero?
-          else
-            return false if ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES.include?(value)
-            !value.blank?
-          end
-        elsif column.number?
+
+        if column.number?
           !value.zero?
         else
           !value.blank?


### PR DESCRIPTION
As discussed [here](https://github.com/byroot/activerecord-typedstore/commit/14cf4112eea017677bbd3793353d286c78e01f93#commitcomment-4560526), this removes the un-used code in `ActiveRecord::TypedStore` extension.
