### PR TITLE
Assigning a hash on the store do not coerce it properly

### DIFF
--- a/lib/active_record/typed_store/coder.rb
+++ b/lib/active_record/typed_store/coder.rb
@@ -17,6 +17,8 @@ module ActiveRecord::TypedStore
 
     end
 
+    delegate :as_indifferent_hash, to: 'self.class'
+
   end
 
 end

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -102,6 +102,16 @@ module ActiveRecord::TypedStore
 
     private
 
+    def write_attribute(attr_name, value)
+      if coder = self.class.serialized_attributes[attr_name]
+        if coder.is_a?(ActiveRecord::TypedStore::Coder)
+          return super(attr_name, coder.as_indifferent_hash(value))
+        end
+      end
+
+      super
+    end
+
     def store_column(store_attribute, key)
       store = store_columns(store_attribute)
       store && store[key]

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -452,6 +452,22 @@ shared_examples 'a store' do |retain_type=true|
 
   let(:model) { described_class.new }
 
+  describe 'assigning the store' do
+
+    it 'coerce it to the proper typed hash' do
+      expect {
+        model.settings = {}
+      }.to_not change { model.settings.class }
+    end
+
+    it 'still handle default values' do
+      expect {
+        model.settings = {}
+      }.to_not change { model.settings['nickname'] }
+    end
+
+  end
+
   describe 'attributes' do
 
     it 'retrieve default if assigned nil and null not allowed' do
@@ -459,9 +475,18 @@ shared_examples 'a store' do |retain_type=true|
       expect(model.age).to be == 12
     end
 
-    it 'retreive default if assigned a blank value and column cannot be blank' do
-      model.update_attributes(nickname: '')
-      expect(model.reload.nickname).to be == 'Please enter your nickname'
+    context 'when column cannot be blank' do
+
+      it 'retreive default if not persisted yet, and nothing was assigned' do
+        expect(model.nickname).to be == 'Please enter your nickname'
+      end
+
+      it 'retreive default if assigned a blank value' do
+        model.update_attributes(nickname: '')
+        expect(model.nickname).to be == 'Please enter your nickname'
+        expect(model.reload.nickname).to be == 'Please enter your nickname'
+      end
+
     end
 
   end


### PR DESCRIPTION
e.g.

``` ruby
>> model = Model.new
>> model.settings.class #=> Model::SettingsHash
>> model.settings = {}
>> model.settings.class # => Hash
```

I though the `:coder` option of serialize was supposed to coerce on assignation, but that's not the case.
We need to decorate the accessor.

/cc @arthurn
