### PR TITLE
remove '-rc1'

### DIFF
--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -5,8 +5,8 @@ require 'active_record/typed_store/typed_hash'
 module ActiveRecord::TypedStore
   AR_VERSION = Gem::Version.new(ActiveRecord::VERSION::STRING)
   IS_AR_3_2 = AR_VERSION < Gem::Version.new('4.0')
-  IS_AR_4_1 = AR_VERSION >= Gem::Version.new('4.1') && AR_VERSION < Gem::Version.new('4.2.0-rc1')
-  IS_AR_4_2 = AR_VERSION >= Gem::Version.new('4.2.0-rc1')
+  IS_AR_4_1 = AR_VERSION >= Gem::Version.new('4.1') && AR_VERSION < Gem::Version.new('4.2.0')
+  IS_AR_4_2 = AR_VERSION >= Gem::Version.new('4.2.0')
 
   module Extension
     extend ActiveSupport::Concern


### PR DESCRIPTION
4.2 is out.  Also, the `-rc1` string breaks `Gem::Version` under 2.0.0:
```
/app/vendor/ruby-2.0.0/lib/ruby/2.0.0/rubygems/version.rb:191:in `initialize': Malformed version number string 4.2.0-rc1 (ArgumentError)
  from /app/vendor/bundle/ruby/2.0.0/gems/activerecord-typedstore-0.5.1/lib/active_record/typed_store/extension.rb:8:in `new'
```