### PR TITLE
Const the coder so we can Marshal the model

### DIFF
--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -47,7 +47,9 @@ module ActiveRecord::TypedStore
       def create_coder(store_attribute, columns)
         store_class = TypedHash.create(columns)
         const_set("#{store_attribute}_hash".camelize, store_class)
-        Coder.create(store_class)
+        coder_class = Coder.create(store_class)
+        const_set("#{store_attribute}_coder".camelize, coder_class)
+        coder_class
       end
 
       def register_typed_store_columns(store_attribute, columns)

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -14,6 +14,14 @@ shared_examples 'any model' do
 
   end
 
+  describe 'Marshal.dump' do
+
+    it 'dumps the model' do
+      Marshal.dump(model)
+    end
+
+  end
+
   describe 'regular AR::Store' do
 
     it 'save attributes as usual' do


### PR DESCRIPTION
without this fix the test fail like so:
```
 1) MarshalTypedStoreModel it should behave like any model Marshal.dump dumps the model
     Failure/Error: Marshal.dump(model)
     TypeError:
       can't dump anonymous class #<Class:0x007fae5b9b02d8>
     Shared Example Group: "any model" called from ./spec/active_record/typed_store_spec.rb:746
     # ./spec/active_record/typed_store_spec.rb:20:in `dump'
     # ./spec/active_record/typed_store_spec.rb:20:in `block (3 levels) in <top (required)>'
```

I guess this only happens for rails 4.2 as the test seems to pass on 4.1

review @byroot 