### PR TITLE
 Implemented opt-out feature for postgres json serialization

### DIFF
--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -21,7 +21,7 @@ module ActiveRecord::TypedStore
       def typed_store(store_attribute, options={}, &block)
         dsl = DSL.new(options.fetch(:accessors, true), &block)
 
-        unless options[:no_coder]
+        unless options[:coder] == false
           coder = create_coder(store_attribute, dsl.columns).new(options[:coder])
           serialize store_attribute, coder
         end

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -21,7 +21,11 @@ module ActiveRecord::TypedStore
       def typed_store(store_attribute, options={}, &block)
         dsl = DSL.new(options.fetch(:accessors, true), &block)
 
-        serialize store_attribute, create_coder(store_attribute, dsl.columns).new(options[:coder])
+        unless options[:no_coder]
+          coder = create_coder(store_attribute, dsl.columns).new(options[:coder])
+          serialize store_attribute, coder
+        end
+
         store_accessor(store_attribute, dsl.accessors)
 
         register_typed_store_columns(store_attribute, dsl.columns)

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -131,6 +131,9 @@ if ENV['POSTGRES']
   class PostgresqlRegularARModel < ActiveRecord::Base
     establish_connection ENV['POSTGRES_URL'] || :test_postgresql
     store :untyped_settings, accessors: [:title]
+    typed_store :settings, coder: ColumnCoder.new(AsJson) do |s|
+      define_store_columns(s)
+    end
   end
 
   if AR_VERSION >= AR_4_0
@@ -144,13 +147,29 @@ if ENV['POSTGRES']
     end
 
     if ENV['POSTGRES_JSON']
-      class PostgresJsonTypedStoreModel < ActiveRecord::Base
-        establish_connection ENV['POSTGRES_URL'] || :test_postgresql
-        store :untyped_settings, accessors: [:title]
-        typed_store :settings, coder: ColumnCoder.new(AsJson) do |s|
-          define_store_columns(s)
+
+      if AR_VERSION >= AR_4_2
+
+        class PostgresJsonTypedStoreModel < ActiveRecord::Base
+          establish_connection ENV['POSTGRES_URL'] || :test_postgresql
+          store :untyped_settings, accessors: [:title]
+          typed_store :settings, coder: false do |s|
+            define_store_columns(s)
+          end
         end
+
+      else
+
+        class PostgresJsonTypedStoreModel < ActiveRecord::Base
+          establish_connection ENV['POSTGRES_URL'] || :test_postgresql
+          store :untyped_settings, accessors: [:title]
+          typed_store :settings, coder: ColumnCoder.new(AsJson) do |s|
+            define_store_columns(s)
+          end
+        end
+
       end
+
     end
 
   end


### PR DESCRIPTION
No need to define dumb coder in each project that is using activerecord-typedstore .