### PR TITLE
fixed coder: false

### DIFF
--- a/lib/active_record/typed_store/dumb_coder.rb
+++ b/lib/active_record/typed_store/dumb_coder.rb
@@ -1,0 +1,16 @@
+module ActiveRecord::TypedStore
+
+  module DumbCoder
+    extend self
+
+    def load(data)
+      data || {}
+    end
+
+    def dump(data)
+      data || {}
+    end
+
+  end
+
+end

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -21,11 +21,9 @@ module ActiveRecord::TypedStore
       def typed_store(store_attribute, options={}, &block)
         dsl = DSL.new(options.fetch(:accessors, true), &block)
 
-        unless options[:coder] == false
-          coder = create_coder(store_attribute, dsl.columns).new(options[:coder])
-          serialize store_attribute, coder
-        end
+        options[:coder] = DumbCoder if  options[:coder] == false
 
+        serialize store_attribute, create_coder(store_attribute, dsl.columns).new(options[:coder])
         store_accessor(store_attribute, dsl.accessors)
 
         register_typed_store_columns(store_attribute, dsl.columns)

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -187,6 +187,7 @@ module ActiveRecord::TypedStore
 
   require 'active_record/typed_store/ar_32_fallbacks' if IS_AR_3_2
   require 'active_record/typed_store/coder'
+  require 'active_record/typed_store/dumb_coder'
 
   unless IS_AR_3_2
     ActiveModel::AttributeMethods::ClassMethods.send(:alias_method, :define_virtual_attribute_method, :define_attribute_method)

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -187,7 +187,7 @@ module ActiveRecord::TypedStore
 
   require 'active_record/typed_store/ar_32_fallbacks' if IS_AR_3_2
   require 'active_record/typed_store/coder'
-  require 'active_record/typed_store/dumb_coder'
+  require 'active_record/typed_store/identity_coder'
 
   unless IS_AR_3_2
     ActiveModel::AttributeMethods::ClassMethods.send(:alias_method, :define_virtual_attribute_method, :define_attribute_method)

--- a/lib/active_record/typed_store/identity_coder.rb
+++ b/lib/active_record/typed_store/identity_coder.rb
@@ -1,6 +1,6 @@
 module ActiveRecord::TypedStore
 
-  module DumbCoder
+  module IdentityCoder
     extend self
 
     def load(data)


### PR DESCRIPTION
coder: false didn't work, because the framework hooks onto the serializer for defining default values and casting types