### PR TITLE
Add support for exposition of accessors on type_store definition

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --format progress
+--backtrace

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --format progress
---backtrace

--- a/lib/active_record/typed_store/dsl.rb
+++ b/lib/active_record/typed_store/dsl.rb
@@ -6,6 +6,8 @@ module ActiveRecord::TypedStore
 
     def initialize(options)
       @coder = options.fetch(:coder) { default_coder }
+      @accessors = options[:accessors]
+      @accessors = [] if options[:accessors] == false
       @fields = {}
       yield self
     end
@@ -15,7 +17,7 @@ module ActiveRecord::TypedStore
     end
 
     def accessors
-      @fields.values.select { |v| v.accessor }.map(&:name)
+      @accessors || @fields.values.select(&:accessor).map(&:name)
     end
 
     delegate :keys, to: :@fields

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -18,7 +18,7 @@ module ActiveRecord::TypedStore
 
       def typed_store(store_attribute, options={}, &block)
         dsl = DSL.new(options, &block)
-        self.typed_stores = {}
+        self.typed_stores ||= {}
         self.typed_stores[store_attribute] = dsl
 
         typed_klass = TypedHash.create(dsl.fields.values)

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -658,16 +658,16 @@ shared_examples 'a store' do |retain_type=true|
   describe 'with no accessors' do
 
     it 'cannot be accessed as a model attribute' do
-      expect(model).to_not respond_to :ip_address
-      expect(model).to_not respond_to :ip_address=
+      expect(model).not_to respond_to :ip_address
+      expect(model).not_to respond_to :ip_address=
     end
 
     it 'cannot be queried' do
-      expect(model).to_not respond_to :ip_address?
+      expect(model).not_to respond_to :ip_address?
     end
 
     it 'cannot be reset' do
-      expect(model).to_not respond_to :reset_ip_address!
+      expect(model).not_to respond_to :reset_ip_address!
     end
 
     it 'does not have dirty accessors' do
@@ -683,7 +683,7 @@ shared_examples 'a store' do |retain_type=true|
   describe 'with some accessors' do
 
     it 'does not define an attribute' do
-      expect(model).to_not respond_to :tax_rate_key
+      expect(model).not_to respond_to :tax_rate_key
     end
 
     it 'define an attribute when included in the accessors array' do

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -526,6 +526,16 @@ shared_examples 'a store' do |retain_type=true|
       stores = model.class.typed_stores
       expect(stores[:settings].keys).to eq [:no_default, :name, :email, :cell_phone, :public, :enabled, :age, :max_length, :rate, :price, :published_on, :remind_on, :published_at, :remind_at, :total_price, :shipping_cost, :grades, :tags, :nickname, :author, :source, :signup, :country]
     end
+
+    it "can access keys even when accessors are not defined" do
+      stores = model.class.typed_stores
+      expect(stores[:explicit_settings].keys).to eq [:ip_address, :user_agent, :signup]
+    end
+
+    it "can access keys even when accessors are partially defined" do
+      stores = model.class.typed_stores
+      expect(stores[:partial_settings].keys).to eq [:tax_rate_key, :tax_rate]
+    end
   end
 
   it 'does not include blank attribute' do
@@ -645,6 +655,43 @@ shared_examples 'a store' do |retain_type=true|
 
   end
 
+  describe 'with no accessors' do
+
+    it 'cannot be accessed as a model attribute' do
+      expect(model).to_not respond_to :ip_address
+      expect(model).to_not respond_to :ip_address=
+    end
+
+    it 'cannot be queried' do
+      expect(model).to_not respond_to :ip_address?
+    end
+
+    it 'cannot be reset' do
+      expect(model).to_not respond_to :reset_ip_address!
+    end
+
+    it 'does not have dirty accessors' do
+      expect(model).not_to respond_to :ip_address_was
+    end
+
+    it 'still has casting a default handling' do
+      expect(model.explicit_settings[:ip_address]).to be == '127.0.0.1'
+    end
+
+  end
+
+  describe 'with some accessors' do
+
+    it 'does not define an attribute' do
+      expect(model).to_not respond_to :tax_rate_key
+    end
+
+    it 'define an attribute when included in the accessors array' do
+      expect(model).to respond_to :tax_rate
+    end
+
+  end
+
   describe '`any` attributes' do
 
     it 'accept any type' do
@@ -664,6 +711,12 @@ shared_examples 'a store' do |retain_type=true|
       model.signup[:counter] = 123
       model.save!
       expect(model.settings[:signup][:counter]).to eq 123
+    end
+
+    it 'works with default hash without affecting unaccessible attributes' do
+      model.signup[:counter] = 123
+      model.save!
+      expect(model.explicit_settings[:signup][:counter]).to be_nil
     end
 
   end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -51,6 +51,21 @@ def define_columns(t)
   t.string :nickname, blank: false, default: 'Please enter your nickname'
 end
 
+def define_store_with_no_attributes(**options)
+  typed_store :explicit_settings, accessors: false, **options do |t|
+    t.string :ip_address, default: '127.0.0.1'
+    t.string :user_agent
+    t.any :signup, default: {}
+  end
+end
+
+def define_store_with_partially_exposed_attributes(**options)
+  typed_store :partial_settings, accessors: [:tax_rate], **options do |t|
+    t.string :tax_rate_key
+    t.string :tax_rate
+  end
+end
+
 def define_store_columns(t)
   define_columns(t)
   t.any :author
@@ -58,6 +73,7 @@ def define_store_columns(t)
   t.any :signup, default: {}
   t.string :country, blank: false, default: 'Canada', accessor: false
 end
+
 
 class CreateAllTables < ActiveRecord::Migration
 
@@ -150,6 +166,9 @@ if ENV['POSTGRES']
       typed_store :settings, coder: ColumnCoder.new(AsJson) do |s|
         define_store_columns(s)
       end
+
+      define_store_with_no_attributes(coder: ColumnCoder.new(AsJson))
+      define_store_with_partially_exposed_attributes(coder: ColumnCoder.new(AsJson))
     end
 
     if ENV['POSTGRES_JSON']
@@ -162,6 +181,9 @@ if ENV['POSTGRES']
           typed_store :settings, coder: false do |s|
             define_store_columns(s)
           end
+
+          define_store_with_no_attributes(coder: false)
+          define_store_with_partially_exposed_attributes(coder: false)
         end
 
       else
@@ -172,6 +194,9 @@ if ENV['POSTGRES']
           typed_store :settings, coder: ColumnCoder.new(AsJson) do |s|
             define_store_columns(s)
           end
+
+          define_store_with_no_attributes(coder: ColumnCoder.new(AsJson))
+          define_store_with_partially_exposed_attributes(coder: ColumnCoder.new(AsJson))
         end
 
       end
@@ -192,6 +217,9 @@ class YamlTypedStoreModel < ActiveRecord::Base
   typed_store :settings do |s|
     define_store_columns(s)
   end
+
+  define_store_with_no_attributes
+  define_store_with_partially_exposed_attributes
 end
 
 class JsonTypedStoreModel < ActiveRecord::Base
@@ -200,6 +228,9 @@ class JsonTypedStoreModel < ActiveRecord::Base
   typed_store :settings, coder: ColumnCoder.new(JSON) do |s|
     define_store_columns(s)
   end
+
+  define_store_with_no_attributes(coder: ColumnCoder.new(JSON))
+  define_store_with_partially_exposed_attributes(coder: ColumnCoder.new(JSON))
 end
 
 module MarshalCoder
@@ -222,6 +253,9 @@ class MarshalTypedStoreModel < ActiveRecord::Base
   typed_store :settings, coder: ColumnCoder.new(MarshalCoder) do |s|
     define_store_columns(s)
   end
+
+  define_store_with_no_attributes(coder: ColumnCoder.new(MarshalCoder))
+  define_store_with_partially_exposed_attributes(coder: ColumnCoder.new(MarshalCoder))
 end
 
 Models = [

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -106,9 +106,9 @@ class CreateAllTables < ActiveRecord::Migration
 
     ActiveRecord::Base.establish_connection(:test_sqlite3)
     recreate_table(:sqlite3_regular_ar_models) { |t| define_columns(t); t.text :untyped_settings }
-    recreate_table(:yaml_typed_store_models) { |t| t.text :settings; t.text :untyped_settings }
-    recreate_table(:json_typed_store_models) { |t| t.text :settings; t.text :untyped_settings }
-    recreate_table(:marshal_typed_store_models) { |t| t.text :settings; t.text :untyped_settings }
+    recreate_table(:yaml_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
+    recreate_table(:json_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
+    recreate_table(:marshal_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
   end
 end
 ActiveRecord::Migration.verbose = true

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -59,21 +59,22 @@ def define_store_with_no_attributes(**options)
   end
 end
 
-def define_store_with_partially_exposed_attributes(**options)
+def define_store_with_partial_attributes(**options)
   typed_store :partial_settings, accessors: [:tax_rate], **options do |t|
     t.string :tax_rate_key
     t.string :tax_rate
   end
 end
 
-def define_store_columns(t)
-  define_columns(t)
-  t.any :author
-  t.any :source, blank: false, default: 'web'
-  t.any :signup, default: {}
-  t.string :country, blank: false, default: 'Canada', accessor: false
+def define_store_with_attributes(**options)
+  typed_store :settings, **options do |t|
+    define_columns(t)
+    t.any :author
+    t.any :source, blank: false, default: 'web'
+    t.any :signup, default: {}
+    t.string :country, blank: false, default: 'Canada', accessor: false
+  end
 end
-
 
 class CreateAllTables < ActiveRecord::Migration
 
@@ -163,12 +164,10 @@ if ENV['POSTGRES']
     class PostgresHstoreTypedStoreModel < ActiveRecord::Base
       establish_connection ENV['POSTGRES_URL'] || :test_postgresql
       store :untyped_settings, accessors: [:title]
-      typed_store :settings, coder: ColumnCoder.new(AsJson) do |s|
-        define_store_columns(s)
-      end
 
+      define_store_with_attributes(coder: ColumnCoder.new(AsJson))
       define_store_with_no_attributes(coder: ColumnCoder.new(AsJson))
-      define_store_with_partially_exposed_attributes(coder: ColumnCoder.new(AsJson))
+      define_store_with_partial_attributes(coder: ColumnCoder.new(AsJson))
     end
 
     if ENV['POSTGRES_JSON']
@@ -178,12 +177,10 @@ if ENV['POSTGRES']
         class PostgresJsonTypedStoreModel < ActiveRecord::Base
           establish_connection ENV['POSTGRES_URL'] || :test_postgresql
           store :untyped_settings, accessors: [:title]
-          typed_store :settings, coder: false do |s|
-            define_store_columns(s)
-          end
 
+          define_store_with_attributes(coder: false)
           define_store_with_no_attributes(coder: false)
-          define_store_with_partially_exposed_attributes(coder: false)
+          define_store_with_partial_attributes(coder: false)
         end
 
       else
@@ -191,12 +188,10 @@ if ENV['POSTGRES']
         class PostgresJsonTypedStoreModel < ActiveRecord::Base
           establish_connection ENV['POSTGRES_URL'] || :test_postgresql
           store :untyped_settings, accessors: [:title]
-          typed_store :settings, coder: ColumnCoder.new(AsJson) do |s|
-            define_store_columns(s)
-          end
 
+          define_store_with_attributes(coder: ColumnCoder.new(AsJson))
           define_store_with_no_attributes(coder: ColumnCoder.new(AsJson))
-          define_store_with_partially_exposed_attributes(coder: ColumnCoder.new(AsJson))
+          define_store_with_partial_attributes(coder: ColumnCoder.new(AsJson))
         end
 
       end
@@ -214,23 +209,19 @@ end
 class YamlTypedStoreModel < ActiveRecord::Base
   establish_connection :test_sqlite3
   store :untyped_settings, accessors: [:title]
-  typed_store :settings do |s|
-    define_store_columns(s)
-  end
 
+  define_store_with_attributes
   define_store_with_no_attributes
-  define_store_with_partially_exposed_attributes
+  define_store_with_partial_attributes
 end
 
 class JsonTypedStoreModel < ActiveRecord::Base
   establish_connection :test_sqlite3
   store :untyped_settings, accessors: [:title]
-  typed_store :settings, coder: ColumnCoder.new(JSON) do |s|
-    define_store_columns(s)
-  end
 
+  define_store_with_attributes(coder: ColumnCoder.new(JSON))
   define_store_with_no_attributes(coder: ColumnCoder.new(JSON))
-  define_store_with_partially_exposed_attributes(coder: ColumnCoder.new(JSON))
+  define_store_with_partial_attributes(coder: ColumnCoder.new(JSON))
 end
 
 module MarshalCoder
@@ -250,12 +241,10 @@ end
 class MarshalTypedStoreModel < ActiveRecord::Base
   establish_connection :test_sqlite3
   store :untyped_settings, accessors: [:title]
-  typed_store :settings, coder: ColumnCoder.new(MarshalCoder) do |s|
-    define_store_columns(s)
-  end
 
+  define_store_with_attributes(coder: ColumnCoder.new(MarshalCoder))
   define_store_with_no_attributes(coder: ColumnCoder.new(MarshalCoder))
-  define_store_with_partially_exposed_attributes(coder: ColumnCoder.new(MarshalCoder))
+  define_store_with_partial_attributes(coder: ColumnCoder.new(MarshalCoder))
 end
 
 Models = [


### PR DESCRIPTION
According to the documentation, it's supposed to be possible to define `accessors: false` or `accessors: [:some_attr]`. This wasn't currently possible since it was always using all the accessors anyways (except when they were explicitly defined on every fields). 

I've also discovered that there was a whole bunch of issues when there's multiple typed_store defined on the same model. Hence the added memoization added here: https://github.com/byroot/activerecord-typedstore/pull/42/files#diff-4f88bac52914df95383817609b009208R21

Thoughts?

@byroot @rafaelfranca 