### PR TITLE
Add prefix to attribute definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ typed_store :settings do |s|
   s.string :postal_code, accessor: false
 end
 
+# or even prefix them
+typed_store :browser, prefix: true do |s|
+  s.string :ip
+end
+
+shop.browser_ip = "127.0.0.1"
+shop.browser[:ip] == shop.browser_ip # => true
+
 ```
 
 Type casting rules and attribute behavior are exactly the same as a for real database columns.
@@ -148,7 +156,7 @@ Since HStore can only store strings:
   - `any` attributes will be converted to string
 
 If you use HStore because you need to be able to query the store from SQL, and any of these limitations are an issue for you,
-than you could probably use the JSON column type, which do not suffer from these limitations and is also queriable. 
+than you could probably use the JSON column type, which do not suffer from these limitations and is also queriable.
 
 ## Contributing
 

--- a/lib/active_record/typed_store/dsl.rb
+++ b/lib/active_record/typed_store/dsl.rb
@@ -8,8 +8,8 @@ module ActiveRecord::TypedStore
       @coder = options.fetch(:coder) { default_coder }
       @accessors = options[:accessors]
       @accessors = [] if options[:accessors] == false
-      @prefix = options[:prefix]
       @fields = {}
+      @prefix = options[:prefix]
       yield self
     end
 
@@ -18,7 +18,7 @@ module ActiveRecord::TypedStore
     end
 
     def accessors
-      @accessors || @fields.values.select(&:accessor).map(&:name)
+      @accessors || prefixed_accessors
     end
 
     delegate :keys, to: :@fields
@@ -30,5 +30,13 @@ module ActiveRecord::TypedStore
       end
     end
     alias_method :date_time, :datetime
+
+    private
+
+    def prefixed_accessors
+      @fields.values
+             .select(&:accessor)
+             .map { |accessor| [@prefix, accessor.name].compact.join('_').to_sym }
+    end
   end
 end

--- a/lib/active_record/typed_store/dsl.rb
+++ b/lib/active_record/typed_store/dsl.rb
@@ -8,6 +8,7 @@ module ActiveRecord::TypedStore
       @coder = options.fetch(:coder) { default_coder }
       @accessors = options[:accessors]
       @accessors = [] if options[:accessors] == false
+      @prefix = options[:prefix]
       @fields = {}
       yield self
     end

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -17,6 +17,8 @@ module ActiveRecord::TypedStore
       end
 
       def typed_store(store_attribute, options={}, &block)
+        options[:prefix] = store_attribute if options[:prefix] == true
+
         dsl = DSL.new(options, &block)
         self.typed_stores ||= {}
         self.typed_stores[store_attribute] = dsl

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -692,6 +692,24 @@ shared_examples 'a store' do |retain_type=true|
 
   end
 
+  describe 'with prefixed accessors' do
+
+    it 'define prefixed accessors' do
+      expect(model).to respond_to :preferences_language
+      expect(model).to respond_to :preferences_language=
+    end
+
+    it 'define prefixed query accessors' do
+      expect(model).to respond_to :preferences_language?
+    end
+
+    it 'does not have accessors when explicitly mentionned' do
+      expect(model).not_to respond_to :timezone
+      expect(model).not_to respond_to :preferences_timezone
+    end
+
+  end
+
   describe '`any` attributes' do
 
     it 'accept any type' do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -76,6 +76,13 @@ def define_store_with_attributes(**options)
   end
 end
 
+def define_store_with_prefix(**options)
+  typed_store :preferences, prefix: true, **options do |t|
+    t.any :language, default: 'fr'
+    t.string :timezone, accessor: false
+  end
+end
+
 class CreateAllTables < ActiveRecord::Migration
 
   def self.recreate_table(name, *args, &block)
@@ -106,9 +113,9 @@ class CreateAllTables < ActiveRecord::Migration
 
     ActiveRecord::Base.establish_connection(:test_sqlite3)
     recreate_table(:sqlite3_regular_ar_models) { |t| define_columns(t); t.text :untyped_settings }
-    recreate_table(:yaml_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
-    recreate_table(:json_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
-    recreate_table(:marshal_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
+    recreate_table(:yaml_typed_store_models) { |t| t.text :settings; t.text :preferences; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
+    recreate_table(:json_typed_store_models) { |t| t.text :settings; t.text :preferences; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
+    recreate_table(:marshal_typed_store_models) { |t| t.text :settings; t.text :preferences; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
   end
 end
 ActiveRecord::Migration.verbose = true
@@ -165,6 +172,7 @@ if ENV['POSTGRES']
       establish_connection ENV['POSTGRES_URL'] || :test_postgresql
       store :untyped_settings, accessors: [:title]
 
+      define_store_with_prefix(coder: ColumnCoder.new(AsJson))
       define_store_with_attributes(coder: ColumnCoder.new(AsJson))
       define_store_with_no_attributes(coder: ColumnCoder.new(AsJson))
       define_store_with_partial_attributes(coder: ColumnCoder.new(AsJson))
@@ -178,6 +186,7 @@ if ENV['POSTGRES']
           establish_connection ENV['POSTGRES_URL'] || :test_postgresql
           store :untyped_settings, accessors: [:title]
 
+          define_store_with_prefix(coder: false)
           define_store_with_attributes(coder: false)
           define_store_with_no_attributes(coder: false)
           define_store_with_partial_attributes(coder: false)
@@ -189,6 +198,7 @@ if ENV['POSTGRES']
           establish_connection ENV['POSTGRES_URL'] || :test_postgresql
           store :untyped_settings, accessors: [:title]
 
+          define_store_with_prefix(coder: ColumnCoder.new(AsJson))
           define_store_with_attributes(coder: ColumnCoder.new(AsJson))
           define_store_with_no_attributes(coder: ColumnCoder.new(AsJson))
           define_store_with_partial_attributes(coder: ColumnCoder.new(AsJson))
@@ -210,6 +220,7 @@ class YamlTypedStoreModel < ActiveRecord::Base
   establish_connection :test_sqlite3
   store :untyped_settings, accessors: [:title]
 
+  define_store_with_prefix
   define_store_with_attributes
   define_store_with_no_attributes
   define_store_with_partial_attributes
@@ -219,6 +230,7 @@ class JsonTypedStoreModel < ActiveRecord::Base
   establish_connection :test_sqlite3
   store :untyped_settings, accessors: [:title]
 
+  define_store_with_prefix(coder: ColumnCoder.new(JSON))
   define_store_with_attributes(coder: ColumnCoder.new(JSON))
   define_store_with_no_attributes(coder: ColumnCoder.new(JSON))
   define_store_with_partial_attributes(coder: ColumnCoder.new(JSON))
@@ -242,6 +254,7 @@ class MarshalTypedStoreModel < ActiveRecord::Base
   establish_connection :test_sqlite3
   store :untyped_settings, accessors: [:title]
 
+  define_store_with_prefix(coder: ColumnCoder.new(MarshalCoder))
   define_store_with_attributes(coder: ColumnCoder.new(MarshalCoder))
   define_store_with_no_attributes(coder: ColumnCoder.new(MarshalCoder))
   define_store_with_partial_attributes(coder: ColumnCoder.new(MarshalCoder))


### PR DESCRIPTION
Whilst adding accessor: false, I thought it would be convenient to add prefix to attributes as well. It also fixes https://github.com/byroot/activerecord-typedstore/issues/7. 

Thoughts?

@byroot @rafaelfranca 