### PR TITLE
Decorate the original type, not replace it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,8 @@ cache: bundler
 before_script:
   - mysql -e 'create database typed_store_test;'
   - psql -c 'create database typed_store_test;' -U postgres
+
+matrix:
+  exclude:
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile.ar-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.3.0
 gemfile:
   - gemfiles/Gemfile.ar-4.2
-  - gemfiles/Gemfile.ar-edge
+  - gemfiles/Gemfile.ar-5.0
 
 env:
   - TIMEZONE_AWARE=1 POSTGRES=1 MYSQL=1

--- a/gemfiles/Gemfile.ar-5.0
+++ b/gemfiles/Gemfile.ar-5.0
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', github: 'rails/rails'
-gem 'arel', github: 'rails/arel'
+gem 'activerecord', '~> 5.0.0'
 gem 'bundler', '~> 1.3'
 gem 'rake'
 gem 'rspec'

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -24,7 +24,9 @@ module ActiveRecord::TypedStore
         typed_klass = TypedHash.create(dsl.fields.values)
         const_set("#{store_attribute}_hash".camelize, typed_klass)
 
-        attribute(store_attribute, Type.new(typed_klass, dsl.coder))
+        decorate_attribute_type(store_attribute, :typed_store) do |subtype|
+          Type.new(typed_klass, dsl.coder, subtype)
+        end
         store_accessor(store_attribute, dsl.accessors)
       end
 

--- a/lib/active_record/typed_store/type.rb
+++ b/lib/active_record/typed_store/type.rb
@@ -1,8 +1,8 @@
 module ActiveRecord::TypedStore
   class Type < ActiveRecord::Type::Serialized
-    def initialize(typed_hash_klass, coder)
+    def initialize(typed_hash_klass, coder, subtype)
       @typed_hash_klass = typed_hash_klass
-      super(ActiveRecord::Type::Value.new, coder)
+      super(subtype, coder)
     end
 
     [:deserialize, :type_cast_from_database, :type_cast_from_user].each do |method|

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -602,6 +602,10 @@ shared_examples 'a store' do |retain_type=true|
       model.reload
       expect(model.settings[:not_existing_key]).to eq 42
     end
+
+    it 'delegates internal methods to the underlying type' do
+      expect(model.class.type_for_attribute("settings").type).to eq :text
+    end
   end
 
   describe 'attributes' do


### PR DESCRIPTION
The current implementation will clobber the underlying datatype. This
means that we lose any casting behavior that it has post-serialization,
and any internal methods aren't delegated.

This specifically caused issues in Shopify core because in 4.2, Active
Record column objects have access to type objects for each attribute,
and delegate internal methods like `type` to it. In Rails 5 columns know
nothing about types, and have a metadata object instead, and this was
leading to cache keys for IDC having a mismatch.

`decorate_attribute_type` is not part of the public external API, but
I super promise that it's stable and safe to rely on.