### PR TITLE
Support Rails 5.1

### DIFF
--- a/activerecord-typedstore.gemspec
+++ b/activerecord-typedstore.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 4.2', '< 5.1'
+  spec.add_dependency 'activerecord', '>= 4.2', '< 5.2'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10'

--- a/gemfiles/Gemfile.ar-5.1
+++ b/gemfiles/Gemfile.ar-5.1
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 5.1.0'
+gem 'bundler', '~> 1.3'
+gem 'rake'
+gem 'rspec'
+gem 'sqlite3'
+gem 'pg', '~> 0.11'
+gem 'mysql2', ['>= 0.3.13', '< 0.5']
+gem 'database_cleaner'
+gem 'coveralls', require: false

--- a/lib/active_record/typed_store/dsl.rb
+++ b/lib/active_record/typed_store/dsl.rb
@@ -4,16 +4,22 @@ module ActiveRecord::TypedStore
   class DSL
     attr_reader :fields, :coder
 
-    def initialize(options)
-      @coder = options.fetch(:coder) { default_coder }
+    def initialize(attribute_name, options)
+      @coder = options.fetch(:coder) { default_coder(attribute_name) }
       @accessors = options[:accessors]
       @accessors = [] if options[:accessors] == false
       @fields = {}
       yield self
     end
 
-    def default_coder
-      ActiveRecord::Coders::YAMLColumn.new
+    if ActiveRecord.gem_version < Gem::Version.new('5.1.0')
+      def default_coder(attribute_name)
+        ActiveRecord::Coders::YAMLColumn.new
+      end
+    else
+      def default_coder(attribute_name)
+        ActiveRecord::Coders::YAMLColumn.new(attribute_name)
+      end
     end
 
     def accessors

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -17,7 +17,7 @@ module ActiveRecord::TypedStore
       end
 
       def typed_store(store_attribute, options={}, &block)
-        dsl = DSL.new(options, &block)
+        dsl = DSL.new(store_attribute, options, &block)
         self.typed_stores ||= {}
         self.typed_stores[store_attribute] = dsl
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -6,12 +6,13 @@ AR_VERSION = Gem::Version.new(ActiveRecord::VERSION::STRING)
 AR_4_0 = Gem::Version.new('4.0')
 AR_4_1 = Gem::Version.new('4.1.0.beta')
 AR_4_2 = Gem::Version.new('4.2.0-rc1')
+AR_5_0 = Gem::Version.new('5.0.0')
 
 ActiveRecord::Base.time_zone_aware_attributes = ENV['TIMEZONE_AWARE'] != '0'
 ActiveRecord::Base.configurations = {
-  'test_sqlite3' => {adapter: 'sqlite3', database: "/tmp/typed_store.db"},
-  'test_postgresql' => {adapter: 'postgresql', database: 'typed_store_test', username: 'postgres'},
-  'test_mysql' => {adapter: 'mysql2', database: 'typed_store_test', username: 'travis'},
+  'test_sqlite3' => { 'adapter' => 'sqlite3', 'database' => '/tmp/typed_store.db' },
+  'test_postgresql' => { 'adapter' => 'postgresql', 'database' => 'typed_store_test', 'username' => 'postgres' },
+  'test_mysql' => { 'adapter' => 'mysql2', 'database' => 'typed_store_test', 'username' => 'travis' },
 }
 
 def define_columns(t)
@@ -76,7 +77,8 @@ def define_store_with_attributes(**options)
   end
 end
 
-class CreateAllTables < ActiveRecord::Migration
+MigrationClass = AR_VERSION >= AR_5_0 ? ActiveRecord::Migration["5.0"] : ActiveRecord::Migration
+class CreateAllTables < MigrationClass
 
   def self.recreate_table(name, *args, &block)
     execute "drop table if exists #{name}"


### PR DESCRIPTION
We still have one deprecation that I'm not sure how to solve it.

The deprecation in question was added by @sgrif in https://github.com/rails/rails/commit/4fed08fa787. It seems that code path was deprecated using two premisses:

* `define_attribute_method` is not common with active record.
* `attribute` works for all the cases.

Both premisses are invalid with this gem. We do use `define_attribute_method` and `attribute` API doesn't work for the specific case of this gem yet.

I tried to override `attribute_will_change!` in this gem but that would require the `attribute_changed?` method to know which typed store it is being used.

I'm more inclined to revert that deprecation, since I could not find a way to make the attributes API work for this gem.

Closes #49