### PR TITLE
Allow nil attribute:

### DIFF
--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -57,12 +57,12 @@ module ActiveRecord::TypedStore
     end
 
     def clear_attribute_change(attr_name)
-      return if self.class.store_accessors.include?(attr_name.to_sym)
+      return if self.class.store_accessors.include?(normalize_attribute(attr_name))
       super
     end
 
     def read_attribute(attr_name)
-      if self.class.store_accessors.include?(attr_name.to_sym)
+      if self.class.store_accessors.include?(normalize_attribute(attr_name))
         return public_send(attr_name)
       end
       super
@@ -94,6 +94,15 @@ module ActiveRecord::TypedStore
         end
       else
         super
+      end
+    end
+
+    def normalize_attribute(attr)
+      case attr
+      when Symbol
+        attr
+      else
+        attr.to_s.to_sym
       end
     end
   end

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -145,6 +145,14 @@ shared_examples 'any model' do
       model.name = 'foo'
       expect(model.read_attribute(:name)).to be == 'foo'
     end
+
+    it 'is accessible through #read_attribute when attribute is nil' do
+      expect(model.read_attribute(nil)).to be_nil
+    end
+
+    it 'allows #increment! when attribute is nil' do
+      expect { model.increment!(nil) }.to raise_error(ActiveModel::MissingAttributeError)
+    end
   end
 
   describe 'string attribute' do


### PR DESCRIPTION
Reading `nil` attribute would throw an exception, because of `attr.to_sym`

- Rails default behavior will accept `nil` attributes when reading a value because it's first [converted](https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/attribute_methods/read.rb#L51) as a string
- This is also the case when dirty attributes are cleared, `clear_attribute_change` callers such as `increment!` / `touch` will first [convert](https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/attribute_mutation_tracker.rb#L33) the attribute to a string

cc/ @rafaelfranca 