### PR TITLE
Avoid overriding the parent class attributes when redefining the same store in a children class

### DIFF
--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -19,6 +19,7 @@ module ActiveRecord::TypedStore
       def typed_store(store_attribute, options={}, &block)
         dsl = DSL.new(store_attribute, options, &block)
         self.typed_stores ||= {}
+        self.typed_stores = typed_stores.deep_dup
         self.typed_stores[store_attribute] = dsl
 
         typed_klass = TypedHash.create(dsl.fields.values)

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -217,6 +217,14 @@ class YamlTypedStoreModel < ActiveRecord::Base
   define_store_with_partial_attributes
 end
 
+class InheritedTypedStoreModel < YamlTypedStoreModel
+  establish_connection :test_sqlite3
+
+  typed_store :settings do |t|
+    t.string :new_attribute
+  end
+end
+
 class JsonTypedStoreModel < ActiveRecord::Base
   establish_connection :test_sqlite3
   store :untyped_settings, accessors: [:title]
@@ -237,7 +245,6 @@ module MarshalCoder
   def dump(value)
     Base64.encode64(Marshal.dump(value))
   end
-
 end
 
 class MarshalTypedStoreModel < ActiveRecord::Base
@@ -252,6 +259,7 @@ end
 Models = [
   Sqlite3RegularARModel,
   YamlTypedStoreModel,
+  InheritedTypedStoreModel,
   JsonTypedStoreModel,
   MarshalTypedStoreModel
 ]


### PR DESCRIPTION
The inherited behavior might still not be what is expected, but at least it won't mutate the parent class anymore.

