### PR TITLE
Support Rails 5.2+

### DIFF
--- a/activerecord-typedstore.gemspec
+++ b/activerecord-typedstore.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 4.2', '< 5.2'
+  spec.add_dependency 'activerecord', '>= 4.2', '<= 5.2.0.beta1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10'

--- a/gemfiles/Gemfile.ar-5.2.beta1
+++ b/gemfiles/Gemfile.ar-5.2.beta1
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '5.2.0.beta1'
+gem 'bundler', '~> 1.3'
+gem 'rake'
+gem 'rspec'
+gem 'sqlite3'
+gem 'pg', '~> 0.11'
+gem 'mysql2', ['>= 0.3.13', '< 0.5']
+gem 'database_cleaner'
+gem 'coveralls', require: false

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -8,19 +8,17 @@ module ActiveRecord::TypedStore
 
     included do
       class_attribute :typed_stores
+      self.typed_stores = {}
     end
 
     module ClassMethods
       def store_accessors
-        return [] unless typed_stores
-        typed_stores.values.map(&:accessors).flatten
+        typed_stores.each_value.flat_map(&:accessors)
       end
 
       def typed_store(store_attribute, options={}, &block)
         dsl = DSL.new(store_attribute, options, &block)
-        self.typed_stores ||= {}
-        self.typed_stores = typed_stores.deep_dup
-        self.typed_stores[store_attribute] = dsl
+        self.typed_stores = self.typed_stores.merge(store_attribute => dsl)
 
         typed_klass = TypedHash.create(dsl.fields.values)
         const_set("#{store_attribute}_hash".camelize, typed_klass)
@@ -29,11 +27,26 @@ module ActiveRecord::TypedStore
           Type.new(typed_klass, dsl.coder, subtype)
         end
         store_accessor(store_attribute, dsl.accessors)
+
+        dsl.accessors.each do |accessor_name|
+          define_method("#{accessor_name}_changed?") do
+            send("#{store_attribute}_changed?") &&
+              send(store_attribute)[accessor_name] != send("#{store_attribute}_was")[accessor_name]
+          end
+
+          define_method("#{accessor_name}_was") do
+            send("#{store_attribute}_was")[accessor_name]
+          end
+
+          define_method("restore_#{accessor_name}!") do
+            send("#{accessor_name}=", send("#{accessor_name}_was"))
+          end
+        end
       end
 
       def define_attribute_methods
         super
-        define_typed_store_attribute_methods if typed_stores
+        define_typed_store_attribute_methods
       end
 
       def undefine_attribute_methods # :nodoc:
@@ -57,6 +70,16 @@ module ActiveRecord::TypedStore
       end
     end
 
+    def changes
+      changes = super
+      self.class.store_accessors.each do |attr|
+        if send("#{attr}_changed?")
+          changes[attr] = [send("#{attr}_was"), send(attr)]
+        end
+      end
+      changes
+    end
+
     def clear_attribute_change(attr_name)
       return if self.class.store_accessors.include?(normalize_attribute(attr_name))
       super
@@ -66,16 +89,6 @@ module ActiveRecord::TypedStore
       if self.class.store_accessors.include?(normalize_attribute(attr_name))
         return public_send(attr_name)
       end
-      super
-    end
-
-    def write_store_attribute(store_attribute, key, value)
-      if typed_stores && typed_stores[store_attribute]
-        prev_value = read_store_attribute(store_attribute, key)
-        new_value = typed_stores[store_attribute].fields[key].cast(value)
-        attribute_will_change!(key.to_s) if new_value != prev_value
-      end
-
       super
     end
 


### PR DESCRIPTION
As of Rails 5.2, `attribute_will_change!` no longer works for
non-attributes. This re-implements the required methods of `Dirty`
manually, similar to what was originally done by this gem.

Note: I don't think it's appropriate to override `changes`. It's
reasonable to expect that `model.changes` will never include keys that
aren't also keys in `model.attributes` or `model.attribute_names`.
I think it would be more appropriate to support the `from:` and `to:`
options in `attribute_changed?` instead.