### PR TITLE
Include IdentityCoder by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,21 +123,7 @@ typed_store :settings, coder: Base64MarshalCoder do |s|
 end
 ```
 
-If you want to use Postgres HStore or JSON column types, then you need a very simple coder:
-```ruby
-module DumbCoder
-  extend self
-
-  def load(data)
-    data || {}
-  end
-
-  def dump(data)
-    data || {}
-  end
-
-end
-```
+If you want to use Postgres HStore or JSON column types, then you can pass in `ActiveRecord::TypedStore::IdentityCoder` as the coder.
 
 ## HStore limitations
 

--- a/lib/active_record/typed_store/identity_coder.rb
+++ b/lib/active_record/typed_store/identity_coder.rb
@@ -1,0 +1,13 @@
+module ActiveRecord::TypedStore
+  module IdentityCoder
+    extend self
+
+    def load(data)
+      data || {}
+    end
+
+    def dump(data)
+      data || {}
+    end
+  end
+end


### PR DESCRIPTION
This is a simple change but it includes the `DumbCoder` out of the box, so projects that use it don't need to maintain that class as well. It appears as though there is precedent for this - In #35 and #38 it looks like it was included and could be enabled by setting `coder: false`. Later on in 051ab0396e266b40ef6859c8ca9e5bd7ae79acb5 it was renamed from `DumbCoder` to `IdentityCoder`.

This change doesn't impact the default options - it doesn't restore the feature where you would do `coder: false` to get it using this coder. If you want to use it you will need to be explicit about it, but at least it's available out-of-the-box. Means it's much easier to pick up and get going when using a HStore or JSON column type.