### PR TITLE
Require identity_coder

### DIFF
--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -1,6 +1,7 @@
 require 'active_record/typed_store/dsl'
 require 'active_record/typed_store/type'
 require 'active_record/typed_store/typed_hash'
+require 'active_record/typed_store/identity_coder'
 
 module ActiveRecord::TypedStore
   module Extension


### PR DESCRIPTION
This was re-introduced in #65, forgot to add a require statement. This just makes the module available by default like the documentation suggests.