### PR TITLE
Remove the upperbound constraint on ActiveRecord:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,24 @@ language: ruby
 
 rvm:
   - 2.3.5
-  - 2.4.2
+  - 2.4.4
 gemfile:
   - gemfiles/Gemfile.ar-4.2
   - gemfiles/Gemfile.ar-5.0
   - gemfiles/Gemfile.ar-5.1
+  - gemfiles/Gemfile.ar-5.2
+  - gemfiles/Gemfile.ar-master
 
 env:
   - TIMEZONE_AWARE=1 POSTGRES=1 MYSQL=1
   - TIMEZONE_AWARE=0 POSTGRES=1 MYSQL=1
   - TIMEZONE_AWARE=1 POSTGRES=1 POSTGRES_JSON=1
   - TIMEZONE_AWARE=0 POSTGRES=1 POSTGRES_JSON=1
+
+matrix:
+  exclude:
+    - rvm: 2.3.5
+      gemfile: 'gemfiles/Gemfile.ar-master'
 
 addons:
   postgresql: 9.3

--- a/activerecord-typedstore.gemspec
+++ b/activerecord-typedstore.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 4.2', '< 5.3'
+  spec.add_dependency 'activerecord', '>= 4.2'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10'

--- a/gemfiles/Gemfile.ar-4.2
+++ b/gemfiles/Gemfile.ar-4.2
@@ -1,11 +1,5 @@
 source 'https://rubygems.org'
 
+gemspec path: '..'
+
 gem 'activerecord', '~> 4.2.1'
-gem 'bundler', '~> 1.3'
-gem 'rake'
-gem 'rspec'
-gem 'sqlite3'
-gem 'pg', '~> 0.11'
-gem 'mysql2', ['>= 0.3.13', '< 0.5']
-gem 'database_cleaner'
-gem 'coveralls', require: false

--- a/gemfiles/Gemfile.ar-5.0
+++ b/gemfiles/Gemfile.ar-5.0
@@ -1,11 +1,5 @@
 source 'https://rubygems.org'
 
+gemspec path: '..'
+
 gem 'activerecord', '~> 5.0.0'
-gem 'bundler', '~> 1.3'
-gem 'rake'
-gem 'rspec'
-gem 'sqlite3'
-gem 'pg', '~> 0.11'
-gem 'mysql2', ['>= 0.3.13', '< 0.5']
-gem 'database_cleaner'
-gem 'coveralls', require: false

--- a/gemfiles/Gemfile.ar-5.1
+++ b/gemfiles/Gemfile.ar-5.1
@@ -1,11 +1,5 @@
 source 'https://rubygems.org'
 
+gemspec path: '..'
+
 gem 'activerecord', '~> 5.1.0'
-gem 'bundler', '~> 1.3'
-gem 'rake'
-gem 'rspec'
-gem 'sqlite3'
-gem 'pg', '~> 0.11'
-gem 'mysql2', ['>= 0.3.13', '< 0.5']
-gem 'database_cleaner'
-gem 'coveralls', require: false

--- a/gemfiles/Gemfile.ar-5.2
+++ b/gemfiles/Gemfile.ar-5.2
@@ -1,11 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', ['>= 5.2.0.beta1', '< 5.3']
-gem 'bundler', '~> 1.3'
-gem 'rake'
-gem 'rspec'
-gem 'sqlite3'
-gem 'pg', '~> 0.11'
-gem 'mysql2', ['>= 0.3.13', '< 0.5']
-gem 'database_cleaner'
-gem 'coveralls', require: false
+gemspec path: '..'
+
+gem 'activerecord', '~> 5.2.0'

--- a/gemfiles/Gemfile.ar-master
+++ b/gemfiles/Gemfile.ar-master
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activerecord', github: 'rails/rails'


### PR DESCRIPTION
Remove development dependencies from Gemfiles:

- They are already listed in the `.gemspec` development dependencies

--------------

Remove the upperbound constraint on ActiveRecord:

- During every ActiveRecord bump, this gemspec needs to be updated,
  I think we are being too conservative and having an upperbound limit
  doesn't help.

  If we wanted to be really conservative we would have to add a
  upperbound constraint on the minor version as well (< 5.x.x) since
  Rails doesn't follow semver and minor version can introduce breaking
  changes.

  What I think is better is to remove the upperbound constraint,
  and test AM directly on ActiveRecord edge