### PR TITLE
Typed hash slice and except

### DIFF
--- a/activerecord-typedstore.gemspec
+++ b/activerecord-typedstore.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', '>= 4.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'coveralls', '~> 0'

--- a/lib/active_record/typed_store/typed_hash.rb
+++ b/lib/active_record/typed_store/typed_hash.rb
@@ -15,6 +15,9 @@ module ActiveRecord::TypedStore
       end
     end
 
+    delegate :with_indifferent_access, to: :to_h
+    delegate :slice, :except, :without, to: :with_indifferent_access
+
     def initialize(constructor={})
       super()
       update(defaults_hash)

--- a/spec/active_record/typed_store/typed_hash_spec.rb
+++ b/spec/active_record/typed_store/typed_hash_spec.rb
@@ -201,7 +201,27 @@ describe ActiveRecord::TypedStore::TypedHash do
         hash.merge!(source: '')
         expect(hash[:source]).to be == 'web'
       end
+
     end
+
+    describe '#except' do
+
+      it 'does not set the default for ignored keys' do
+        hash = hash_class.new(source: 'foo')
+        expect(hash.except(:source)).to_not have_key(:source)
+      end
+
+    end
+
+    describe '#slice' do
+
+      it 'does not set the default for ignored keys' do
+        hash = hash_class.new(source: 'foo')
+        expect(hash.slice(:not_source)).to_not have_key(:source)
+      end
+
+    end
+
   end
 
   context 'unknown columns' do


### PR DESCRIPTION
### Context

`TypedHash` inherits from `HashWithIndifferentAccess`, a while ago many methods like `.except()`would return a true `HashWithIndifferentAccess`, but recently they changed to return an instance of the same class than the initial hash.

First `slice` in 2017 https://github.com/rails/rails/commit/d6f3b91aaa4af88eda2344629afed64640d51e0f and more recently `except` in 2019: https://github.com/rails/rails/commit/a805d72e901f81f5b043dfd9904b80ce93ebfc01#diff-9f4b3d7342097a6f22290f147a09b77b

The problem with this is that `TypedHash` can contain default values for keys, so if you clear a a key with a default, it will be reset on the new instance, which makes for confusing defaults.

e.g.: `{age: 42}.except(:age) => {age: 0}` while you'd likely expect `{}`.

### Solution

We first cast to `HashWIthIndifferentAccess` before calling these methods. 

@rafaelfranca thoughts?