### PR TITLE
Fix TypedStore inheritance

### DIFF
--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -23,6 +23,7 @@ module ActiveRecord::TypedStore
 
       if ActiveRecord.version >= Gem::Version.new('6.1.0.alpha')
         attribute(store_attribute) do |subtype|
+          subtype = subtype.subtype if subtype.is_a?(Type)
           Type.new(typed_klass, dsl.coder, subtype)
         end
       else

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -867,9 +867,4 @@ describe InheritedTypedStoreModel do
     model.update(new_attribute: 42)
     expect(model.settings[:new_attribute]).to be == '42'
   end
-
-  it 'inherits attributes from parent' do
-    skip 'to be implemented'
-    expect(model.total_price).to be == 4.2
-  end
 end

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -854,3 +854,22 @@ describe MarshalTypedStoreModel do
   it_should_behave_like 'a store'
   it_should_behave_like 'a model supporting arrays'
 end
+
+describe InheritedTypedStoreModel do
+  let(:model) { described_class.new }
+
+  it 'can be serialized' do
+    model.update(new_attribute: "foobar")
+    expect(model.reload.new_attribute).to be == "foobar"
+  end
+
+  it 'is casted' do
+    model.update(new_attribute: 42)
+    expect(model.settings[:new_attribute]).to be == '42'
+  end
+
+  it 'inherits attributes from parent' do
+    skip 'to be implemented'
+    expect(model.total_price).to be == 4.2
+  end
+end


### PR DESCRIPTION
Fix typed store attribute getting double serialized in cases where model inherits from a superclass with typed store settings, in which case the attribute's subtype may already be a `ActiveRecord::TypedStore::Type`. 