### PR TITLE
Don't include whole Hash field to changes

### DIFF
--- a/lib/active_record/typed_store/behavior.rb
+++ b/lib/active_record/typed_store/behavior.rb
@@ -32,7 +32,7 @@ module ActiveRecord::TypedStore
     end
 
     def changes
-      changes = super
+      changes = super.except(*self.class.typed_stores.keys.map(&:to_s))
       self.class.store_accessors.each do |attr|
         if send("#{attr}_changed?")
           changes[attr] = [send("#{attr}_was"), send(attr)]

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -109,6 +109,18 @@ shared_examples 'any model' do
         model.name = ""
       }.to_not change { !!model.name_changed? }
     end
+
+    it 'does not include whole fields (settings) to #changes' do
+      expect {
+        model.name = "Smith"
+      }.to change { model.changes }.from({}).to({"name"=>["", "Smith"]})
+    end
+
+    it 'include not typed json field to #changes' do
+      expect {
+        model.untyped_settings = {name: "Smith"}
+      }.to change { model.changes }.from({}).to({"untyped_settings"=>[{}, {"name"=>"Smith"}]})
+    end
   end
 
   describe 'unknown attribute' do
@@ -656,7 +668,6 @@ shared_examples 'a store' do |retain_type = true, settings_type = :text|
     it 'still has casting a default handling' do
       expect(model.settings[:country]).to be == 'Canada'
     end
-
   end
 
   describe 'with no accessors' do


### PR DESCRIPTION
### Problem

ActiveModel::Dirty does not check Hash attributes for changes and considers them to be alwayes changed
(discution: https://github.com/rails/rails/issues/34537; code: https://github.com/rails/rails/blob/06ab7b27ea1c1ab357085439abacdb464f6742bf/activerecord/lib/active_record/store.rb#L181)
This results in having model.changes not to be empty even if no changes has been provided and having all Hash in changes for small changes, thats why
1. paper_trail becomes useless for Hash fields (ex.: jsonb in postgresql)
2. model.with_lock{} sometimes raise "locking a record with unpersisted changes is not supported", cause changes are not empty

### Decision

Remove fields, described as typed_store from ActiveModel::Dirty changes