### PR TITLE
Inline syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 gemfiles/*.lock
 
+/.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in active_record_typed_store.gemspec
 gemspec
+
+group :development, :test do
+  gem 'ruby_jard', git: 'https://github.com/nguyenquangminh0711/ruby_jard'
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,10 @@
+clearing :on
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_files)
+end

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If not, then please fill in an issue.
 Just like for store, you can use any custom coder:
 
 ```ruby
+
 module Base64MarshalCoder
   extend self
 
@@ -127,6 +128,7 @@ end
 typed_store :settings, coder: Base64MarshalCoder do |s|
   # ...
 end
+
 ```
 
 If you want to use JSON column or Postgres HStore types, then you can pass in `ActiveRecord::TypedStore::IdentityCoder` as the coder.
@@ -152,6 +154,7 @@ behave the same. It is being set to `StrippedCoder`, which ensures that if a fie
 it is being excluded from the persisted hash, keeping it tidy and minimalistic.
 
 ```ruby
+
 class ApplicationRecord < ActiveRecord::Base
   typed_store_coder ActiveRecord::TypedStore::StrippedCoder.new
 end
@@ -159,6 +162,7 @@ end
 class User < ApplicationRecord
   typed_store :preferences, auto_close_modals: :boolean, keep_me_signed_in: [:boolean, default: true]
 end
+
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ typed_store :settings do |s|
   s.string :postal_code, accessor: false
 end
 
+# an inline DSL is also available, to keep it a one-liner like with basic Rails store
+typed_store :settings, email: :string, publish_at: :datetime, age: [:integer, null: false], public: [:boolean, default: false, null: false]
+
+# it's even possible to send `typed_store` basic options prefixing them with an underscore
+typed_store :settings, _coder: JSON, email: :string, publish_at: :datetime
+
 ```
 
 Type casting rules and attribute behavior are exactly the same as for real database columns.
@@ -135,6 +141,25 @@ Since HStore can only store strings:
 
 If you use HStore because you need to be able to query the store from SQL, and any of these limitations are an issue for you,
 then you could probably use the JSON column type, which do not suffer from these limitations and is also queriable. 
+
+## Setting a default coder
+
+If you desire to use a different default coder, it is possible by simply setting it in the base
+model class of your app.
+
+In this example, we are setting it `ApplicationRecord`, so all models of our _Rails_ application
+behave the same. It is being set to `StrippedCoder`, which ensures that if a field is nil or empty,
+it is being excluded from the persisted hash, keeping it tidy and minimalistic.
+
+```ruby
+class ApplicationRecord < ActiveRecord::Base
+  typed_store_coder ActiveRecord::TypedStore::StrippedCoder.new
+end
+
+class User < ApplicationRecord
+  typed_store :preferences, auto_close_modals: :boolean, keep_me_signed_in: [:boolean, default: true]
+end
+```
 
 ## Contributing
 

--- a/activerecord-typedstore.gemspec
+++ b/activerecord-typedstore.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-rails'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rspec'
-  spec.add_development_dependency 'ruby_jard'
 end

--- a/activerecord-typedstore.gemspec
+++ b/activerecord-typedstore.gemspec
@@ -28,4 +28,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pg', ENV.fetch('PG_VERSION', '~> 0.18')
   spec.add_development_dependency 'mysql2', '> 0.3'
   spec.add_development_dependency 'database_cleaner', '~> 1'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'pry-doc'
+  spec.add_development_dependency 'pry-stack_explorer'
+  spec.add_development_dependency 'pry-rails'
+  spec.add_development_dependency 'guard'
+  spec.add_development_dependency 'guard-rspec'
+  spec.add_development_dependency 'ruby_jard'
 end

--- a/lib/active_record/typed_store/dsl.rb
+++ b/lib/active_record/typed_store/dsl.rb
@@ -6,8 +6,8 @@ module ActiveRecord::TypedStore
   class DSL
     attr_reader :fields, :coder
 
-    def initialize(attribute_name, options)
-      @coder = options.fetch(:coder) { default_coder(attribute_name) }
+    def initialize(attribute_name, options, model_default_typed_store_coder)
+      @coder = options[:coder] || model_default_typed_store_coder || default_coder(attribute_name)
       @accessors = options[:accessors]
       @accessors = [] if options[:accessors] == false
       @fields = {}
@@ -23,6 +23,8 @@ module ActiveRecord::TypedStore
         ActiveRecord::Coders::YAMLColumn.new(attribute_name)
       end
     end
+
+    DEFAULT_TYPED_STORE_CODER_METHOD = :default_typed_store_coder
 
     def accessors
       @accessors || @fields.values.select(&:accessor).map(&:name)

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -5,6 +5,7 @@ require 'active_record/typed_store/behavior'
 require 'active_record/typed_store/type'
 require 'active_record/typed_store/typed_hash'
 require 'active_record/typed_store/identity_coder'
+require 'active_record/typed_store/stripped_coder'
 
 module ActiveRecord::TypedStore
   module Extension
@@ -16,7 +17,7 @@ module ActiveRecord::TypedStore
         class_attribute :typed_stores, :store_accessors, instance_accessor: false
       end
 
-      dsl = DSL.new(store_attribute, options, &block)
+      dsl = DSL.new(store_attribute, options, @typed_store_coder, &block)
       self.typed_stores = (self.typed_stores || {}).merge(store_attribute => dsl)
       self.store_accessors = typed_stores.each_value.flat_map(&:accessors).map { |a| -a.to_s }.to_set
 
@@ -64,6 +65,10 @@ module ActiveRecord::TypedStore
           s.send type, name, **(settings || {})
         end
       end
+    end
+
+    def typed_store_coder(coder)
+      @typed_store_coder = coder
     end
   end
 end

--- a/lib/active_record/typed_store/extension.rb
+++ b/lib/active_record/typed_store/extension.rb
@@ -17,7 +17,7 @@ module ActiveRecord::TypedStore
         class_attribute :typed_stores, :store_accessors, instance_accessor: false
       end
 
-      dsl = DSL.new(store_attribute, options, @typed_store_coder, &block)
+      dsl = DSL.new(store_attribute, options, typed_store_coder, &block)
       self.typed_stores = (self.typed_stores || {}).merge(store_attribute => dsl)
       self.store_accessors = typed_stores.each_value.flat_map(&:accessors).map { |a| -a.to_s }.to_set
 
@@ -67,8 +67,12 @@ module ActiveRecord::TypedStore
       end
     end
 
-    def typed_store_coder(coder)
-      @typed_store_coder = coder
+    def typed_store_coder(coder = nil)
+      return @typed_store_coder = coder if coder
+
+      result = @typed_store_coder
+      result ||= ancestors.lazy.drop(1).filter_map { |a| a.typed_store_coder if a.respond_to?(:typed_store_coder) }.first
+      result
     end
   end
 end

--- a/lib/active_record/typed_store/stripped_coder.rb
+++ b/lib/active_record/typed_store/stripped_coder.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActiveRecord::TypedStore
+  class StrippedCoder
+    def initialize(coder = JSON)
+      @coder = coder || raise(ArgumentError, "needs to be based on another coder (can't be nil)")
+    end
+
+    def load(data)
+      @coder.load(data) || {}
+    end
+
+    def dump(data)
+      stripped = (data || {}).filter do |_k, value|
+        value.present? || value.is_a?(FalseClass)
+      end
+      @coder.dump(stripped)
+    end
+  end
+end

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -903,12 +903,10 @@ describe JsonTypedStoreModelWithDefaultStrippedCoder do
 
   it 'exclude nil attributes' do
     model.update! character_name: "Something"
-    puts model.reload.inline_settings
     expect(model.reload.inline_settings.keys).to include "character_name"
     expect(model.reload.character_name).to eq "Something"
 
     model.update! character_name: ""
-    puts model.reload.inline_settings
     expect(model.reload.inline_settings.keys).not_to include "character_name"
     expect(model.reload.character_name).to be_nil
   end
@@ -918,5 +916,5 @@ describe JsonTypedStoreModelWithDefaultStrippedCoder do
     expect(model.reload.inline_settings.keys).to include "npc"
     expect(model.reload.npc).to eq false
   end
-  
+
 end

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -899,6 +899,7 @@ describe InheritedTypedStoreModel do
 end
 
 describe JsonTypedStoreModelWithDefaultStrippedCoder do
+
   let(:model) { described_class.new }
 
   it 'exclude nil attributes' do

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -744,7 +744,7 @@ shared_examples 'a store' do |retain_type = true, settings_type = :text|
 
     it 'set default value' do
       expect(model.level).to eq 2
-      expect(model.level).to eq true
+      expect(model.npc).to eq true
     end
 
   end

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -897,3 +897,26 @@ describe InheritedTypedStoreModel do
     expect(model.settings[:new_attribute]).to be == '42'
   end
 end
+
+describe JsonTypedStoreModelWithDefaultStrippedCoder do
+  let(:model) { described_class.new }
+
+  it 'exclude nil attributes' do
+    model.update! character_name: "Something"
+    puts model.reload.inline_settings
+    expect(model.reload.inline_settings.keys).to include "character_name"
+    expect(model.reload.character_name).to eq "Something"
+
+    model.update! character_name: ""
+    puts model.reload.inline_settings
+    expect(model.reload.inline_settings.keys).not_to include "character_name"
+    expect(model.reload.character_name).to be_nil
+  end
+
+  it 'keeps `false` values' do
+    model.update! npc: false
+    expect(model.reload.inline_settings.keys).to include "npc"
+    expect(model.reload.npc).to eq false
+  end
+  
+end

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -729,6 +729,25 @@ shared_examples 'a store' do |retain_type = true, settings_type = :text|
     end
 
   end
+
+  describe 'attributes defined with the inline DSL' do
+
+    it 'coerce string attribute' do
+      model.update! character_name: 123
+      expect(model.reload.character_name).to eq "123"
+    end
+
+    it 'coerce integer attribute' do
+      model.update! level: "42"
+      expect(model.reload.level).to eq 42
+    end
+
+    it 'set default value' do
+      expect(model.level).to eq 2
+      expect(model.level).to eq true
+    end
+
+  end
 end
 
 shared_examples 'a db backed model' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
 SimpleCov.start
 
 require 'activerecord-typedstore'
+require 'pry'
+require 'ruby_jard'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].each { |f| require f }
 
@@ -19,4 +21,5 @@ Time.zone = 'UTC'
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.filter_run_when_matching :focus
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -206,13 +206,18 @@ class JsonTypedStoreModel < ActiveRecord::Base
   define_store_with_inline_dsl(coder: ColumnCoder.new(JSON))
 end
 
-class JsonTypedStoreModelWithDefaultStrippedCoder < ActiveRecord::Base
+class JsonTypedStoreModelWithDefaultStrippedCoderSuperClass < ActiveRecord::Base
+  self.table_name = 'json_typed_store_models'
+  establish_connection :test_sqlite3
+
+  typed_store_coder ActiveRecord::TypedStore::StrippedCoder.new
+end
+
+class JsonTypedStoreModelWithDefaultStrippedCoder < JsonTypedStoreModelWithDefaultStrippedCoderSuperClass
   self.table_name = 'json_typed_store_models'
   establish_connection :test_sqlite3
   store :untyped_settings, accessors: [:title]
 
-  # typed_store_coder JSON
-  typed_store_coder ActiveRecord::TypedStore::StrippedCoder.new
   define_store_with_inline_dsl
 end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -206,6 +206,16 @@ class JsonTypedStoreModel < ActiveRecord::Base
   define_store_with_inline_dsl(coder: ColumnCoder.new(JSON))
 end
 
+class JsonTypedStoreModelWithDefaultStrippedCoder < ActiveRecord::Base
+  self.table_name = 'json_typed_store_models'
+  establish_connection :test_sqlite3
+  store :untyped_settings, accessors: [:title]
+
+  # typed_store_coder JSON
+  typed_store_coder ActiveRecord::TypedStore::StrippedCoder.new
+  define_store_with_inline_dsl
+end
+
 module MarshalCoder
   extend self
 
@@ -234,6 +244,7 @@ Models = [
   YamlTypedStoreModel,
   InheritedTypedStoreModel,
   JsonTypedStoreModel,
+  JsonTypedStoreModelWithDefaultStrippedCoder,
   MarshalTypedStoreModel
 ]
 Models << MysqlRegularARModel if defined?(MysqlRegularARModel)

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -74,6 +74,11 @@ def define_store_with_attributes(**options)
   end
 end
 
+def define_store_with_inline_dsl(**options)
+  underscored_options = options.transform_keys { |k| :"_#{k}" }
+  typed_store :inline_settings, underscored_options.merge(character_name: :string, level: [:integer, default: 2], npc: [:boolean, null: true, default: true])
+end
+
 MigrationClass = ActiveRecord::Migration["5.0"]
 class CreateAllTables < MigrationClass
 
@@ -96,15 +101,15 @@ class CreateAllTables < MigrationClass
       recreate_table(:postgres_hstore_typed_store_models) { |t| t.hstore :settings; t.text :untyped_settings }
 
       if ENV['POSTGRES_JSON']
-        recreate_table(:postgres_json_typed_store_models) { |t| t.json :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
+        recreate_table(:postgres_json_typed_store_models) { |t| t.json :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings; t.json :inline_settings }
       end
     end
 
     ActiveRecord::Base.establish_connection(:test_sqlite3)
     recreate_table(:sqlite3_regular_ar_models) { |t| define_columns(t); t.text :untyped_settings }
-    recreate_table(:yaml_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
-    recreate_table(:json_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
-    recreate_table(:marshal_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings }
+    recreate_table(:yaml_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings; t.text :inline_settings }
+    recreate_table(:json_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings; t.text :inline_settings }
+    recreate_table(:marshal_typed_store_models) { |t| t.text :settings; t.text :explicit_settings; t.text :partial_settings; t.text :untyped_settings; t.text :inline_settings }
   end
 end
 ActiveRecord::Migration.verbose = true
@@ -163,6 +168,7 @@ if ENV['POSTGRES']
       define_store_with_attributes(coder: ColumnCoder.new(AsJson))
       define_store_with_no_attributes(coder: ColumnCoder.new(AsJson))
       define_store_with_partial_attributes(coder: ColumnCoder.new(AsJson))
+      define_store_with_inline_dsl(coder: ColumnCoder.new(AsJson))
     end
   end
 end
@@ -179,6 +185,7 @@ class YamlTypedStoreModel < ActiveRecord::Base
   define_store_with_attributes
   define_store_with_no_attributes
   define_store_with_partial_attributes
+  define_store_with_inline_dsl
 end
 
 class InheritedTypedStoreModel < YamlTypedStoreModel
@@ -196,6 +203,7 @@ class JsonTypedStoreModel < ActiveRecord::Base
   define_store_with_attributes(coder: ColumnCoder.new(JSON))
   define_store_with_no_attributes(coder: ColumnCoder.new(JSON))
   define_store_with_partial_attributes(coder: ColumnCoder.new(JSON))
+  define_store_with_inline_dsl(coder: ColumnCoder.new(JSON))
 end
 
 module MarshalCoder
@@ -218,6 +226,7 @@ class MarshalTypedStoreModel < ActiveRecord::Base
   define_store_with_attributes(coder: ColumnCoder.new(MarshalCoder))
   define_store_with_no_attributes(coder: ColumnCoder.new(MarshalCoder))
   define_store_with_partial_attributes(coder: ColumnCoder.new(MarshalCoder))
+  define_store_with_inline_dsl(coder: ColumnCoder.new(MarshalCoder))
 end
 
 Models = [


### PR DESCRIPTION
# New Features in This PR

## Inline Syntax

It's important to me and my colleague that the stored attribute definition be kept as much as possible a one-liner, as it would be with a basic untyped _Rails_ stored attributes approach. To achieve this, I made available a one-liner DSL approach, where all of the information can be compacted in one call, without passing a block (see README for and example).

## StrippedCoder

Another requirement we have is that attributes that are empty or nil should not be included at all in the hash being persisted (in our case: PostgreSQL JSONB field). To achieve that, I made the following modifications:
- created the `StrippedCoder`, which by default is itself calling the `JSON` coder, but can be based on whatever its constructor receives.
- made it possible for a model class to set a default coder for `typed_store`, main usecase being to set it in the `ApplicationRecord` of our _Rails_ app, so all our models using a `typed_store` behave the same (using the `StrippedCoder`, per instance).
