### PR TITLE
Made #changed_in_place? to compare deserialized values

### DIFF
--- a/lib/active_record/typed_store/type.rb
+++ b/lib/active_record/typed_store/type.rb
@@ -41,13 +41,8 @@ module ActiveRecord::TypedStore
 
     def changed_in_place?(raw_old_value, value)
       return false if value.nil?
-      if ActiveRecord.version.segments.first >= 5
-        raw_new_value = serialize(value)
-      else
-        # 4.2 capability
-        raw_new_value = type_cast_for_database(value)
-      end
-      raw_old_value.nil? != raw_new_value.nil? || raw_old_value != raw_new_value
+
+      value != deserialize(raw_old_value)
     end
   end
 end

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -545,6 +545,16 @@ shared_examples 'a store' do |retain_type = true, settings_type = :text|
     expect(model.settings).not_to have_key(:remind_on)
   end
 
+  describe 'dirty tracking' do
+    context 'with multiple fields' do
+      it 'is order agnostic' do
+        model.save!
+        expect { model.settings[:name] = model.settings.delete(:name) }
+          .not_to(change { model.changed? }.from(false))
+      end
+    end
+  end
+
   describe 'assigning the store' do
     it 'handles mutated value' do
       model.save!


### PR DESCRIPTION
### The Aim
This PR addresses the issue mentioned in https://github.com/byroot/activerecord-typedstore/issues/58.

In short: currentrly in some scenarios a freshly loaded record could be considered as changed by rails.
So it could result in the following:
```ruby
user = User.first
user.changed? # => true
```

### The Idea
Now `#changed_in_place?` compares not the serialized versions of fields but deserialized versions instead.

### Drawbacks
The new algorythm can cause decrease in performance, because now it has to decerialize the original value every time the changes are checked.
However, prior to this change the new value had to be serialized, so overall overhead should not increase too much.