### PR TITLE
Persist default values for Rails 6.1

### DIFF
--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -958,6 +958,7 @@ end
 describe DirtyTrackingModel do
   it 'stores the default on creation' do
     model = DirtyTrackingModel.create!
+    model = DirtyTrackingModel.find(model.id)
     expect(model.settings_before_type_cast).to_not be_blank
   end
 
@@ -972,5 +973,14 @@ describe DirtyTrackingModel do
 
     expect(model.settings_changed?).to be false
     expect(model.changes).to be_empty
+  end
+
+  it 'does not update missing attributes in partially loaded records' do
+    model = DirtyTrackingModel.create!(active: true)
+    model = DirtyTrackingModel.select(:id, :title).find(model.id)
+    model.update!(title: "Hello")
+
+    model = DirtyTrackingModel.find(model.id)
+    expect(model.active).to be true
   end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -190,7 +190,7 @@ Models = [
 ]
 
 class DirtyTrackingModel < ActiveRecord::Base
-  after_update :read_active
+  after_update :read_active, if: -> { has_attribute?(:settings) }
 
   typed_store(:settings) do |f|
     f.boolean :active, default: false, null: false


### PR DESCRIPTION
This extends the fix from 1f150f6bc3194f803b15c400513f07aacf53939b to Rails 6.1, and adds test coverage.  Specifically, it adds a record reload to the "stores the default on creation" test to ensure that the postcondition holds.  Without the reload, the "stores the default on creation" test would pass even before 1f150f6bc3194f803b15c400513f07aacf53939b.

This commit also adds a test for when the record is partially loaded, and changes some Rails private API calls to equivalent public API calls.

---

Extracted from #96.
