### PR TITLE
Fix array set to [] when value is nil and default is provided

### DIFF
--- a/lib/active_record/typed_store/field.rb
+++ b/lib/active_record/typed_store/field.rb
@@ -11,12 +11,15 @@ module ActiveRecord::TypedStore
 
       @accessor = options.fetch(:accessor, true)
       @name = name
+      # Got to move @array up so that #extract_default -> #type_cast
+      # can cast the array properly instead of stringify the default
+      # array provided
+      @array = options.fetch(:array, false)
       if options.key?(:default)
         @default = extract_default(options[:default])
       end
       @null = options.fetch(:null, true)
       @blank = options.fetch(:blank, true)
-      @array = options.fetch(:array, false)
     end
 
     def has_default?

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -524,7 +524,7 @@ shared_examples 'a store' do |retain_type = true, settings_type = :text|
   describe 'model.typed_stores' do
     it "can access keys" do
       stores = model.class.typed_stores
-      expect(stores[:settings].keys).to eq [:no_default, :name, :email, :cell_phone, :public, :enabled, :age, :max_length, :rate, :price, :published_on, :remind_on, :published_at_time, :remind_at_time, :published_at, :remind_at, :total_price, :shipping_cost, :grades, :tags, :nickname, :author, :source, :signup, :country]
+      expect(stores[:settings].keys).to eq [:no_default, :name, :email, :cell_phone, :public, :enabled, :age, :max_length, :rate, :price, :published_on, :remind_on, :published_at_time, :remind_at_time, :published_at, :remind_at, :total_price, :shipping_cost, :grades, :tags, :subjects, :nickname, :author, :source, :signup, :country]
     end
 
     it "can access keys even when accessors are not defined" do
@@ -887,6 +887,11 @@ shared_examples 'a model supporting arrays' do |pg_native=false|
     it 'accept non rectangular multidimensianl arrays' do
       model.update(grades: [[1, 2], [3, 4, 5]])
       expect(model.reload.grades).to be == [[1, 2], [3, 4, 5]]
+    end
+
+    it 'defaults to [] if provided default is not an array' do
+      model.update(subjects: nil)
+      expect(model.reload.subjects).to be == []
     end
 
     # Not sure about pg_native and if this test should be outside of this block.

--- a/spec/active_record/typed_store_spec.rb
+++ b/spec/active_record/typed_store_spec.rb
@@ -889,9 +889,10 @@ shared_examples 'a model supporting arrays' do |pg_native=false|
       expect(model.reload.grades).to be == [[1, 2], [3, 4, 5]]
     end
 
+    # Not sure about pg_native and if this test should be outside of this block.
     it 'retreive default if assigned null' do
       model.update(tags: nil)
-      expect(model.reload.tags).to be == []
+      expect(model.reload.tags).to be == ['article']
     end
   end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -44,6 +44,7 @@ def define_columns(t, array: false)
   if t.is_a?(ActiveRecord::TypedStore::DSL)
     t.integer :grades, array: true
     t.string :tags, array: true, null: false, default: ['article']
+    t.string :subjects, array: true, null: false, default: ['mathematics'].to_yaml
 
     t.string :nickname, blank: false, default: 'Please enter your nickname'
   end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -43,7 +43,7 @@ def define_columns(t, array: false)
 
   if t.is_a?(ActiveRecord::TypedStore::DSL)
     t.integer :grades, array: true
-    t.string :tags, array: true, null: false, default: [].to_yaml
+    t.string :tags, array: true, null: false, default: ['article']
 
     t.string :nickname, blank: false, default: 'Please enter your nickname'
   end


### PR DESCRIPTION
Bug issue: https://github.com/byroot/activerecord-typedstore/issues/80

Took a stab at this bug because I was hoping to use this feature. Added comments in the code to try to explain what is wrong and what are my recommendations. 

I have identified 2 problems that caused this to happen.
1. When `#extract_default` happens, `#type_cast` wrongly cast the default value to the stringified version of the array because `@array` was not set yet and the default value is not `nil`. 
2. During the cast of the actual value (which is `nil`), `@array` is set but value is a String. `[]` is then returned. 

Recommendations
1. Assign `@array` before extracting the default value. This allows the default to be casted properly.
2. If 1) the option `array: true` is set, 2) a default is provided and 3) value is `nil`; always default to the provided default. 

Happy to hear any feedbacks and take any recommendations. 
 